### PR TITLE
Update dockerfile to fix trivy scan warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,14 @@ RUN npm run build
 
 FROM python:3.13-bookworm AS base
 ARG REQUIREMENTS_FILE=requirements-production.txt
-RUN apt-get update
-# Upgrade perl-base to install latests security update
+# Security updates for perl-base + libxslt and then clean apt lists
 # https://avd.aquasec.com/nvd/2024/cve-2024-56406/
-RUN apt-get install --only-upgrade perl-base -y
+RUN apt-get update \
+    && apt-get install  --only-upgrade -y \
+    perl-base \
+    libxslt1.1 \
+    libxslt1-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 # Set environment variables
 ENV FLASK_RUN_HOST=0.0.0.0


### PR DESCRIPTION
## What does this pull request do?

update libxslt1 as current version fails trivy scan due to security vulnerability
combines this with the perl-base update
tidy up the apt-get lists after install completes

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
