### PR TITLE
MAPD-121 Office contact details

### DIFF
--- a/app/main/add_a_new_office/forms.py
+++ b/app/main/add_a_new_office/forms.py
@@ -118,19 +118,19 @@ class OfficeContactDetailsForm(BaseForm):
 
     # Contact fields
     telephone_number = StringField(
-        "Telephone number",
+        "Telephone number (optional)",
         widget=GovTextInput(heading_class="govuk-fieldset__legend--m", classes="govuk-input--width-20"),
         validators=[
-            InputRequired(message="Enter the telephone number"),
+            Optional(),
             Length(max=20, message="Telephone number must be 20 characters or fewer"),
         ],
     )
 
     email_address = StringField(
-        "Email address",
+        "Email address (optional)",
         widget=GovTextInput(heading_class="govuk-fieldset__legend--m", classes="govuk-!-width-full"),
         validators=[
-            InputRequired(message="Enter the email address"),
+            Optional(),
             Email(message="Enter a valid email address"),
             Length(max=100, message="Email address must be 100 characters or fewer"),
         ],
@@ -138,19 +138,19 @@ class OfficeContactDetailsForm(BaseForm):
 
     # DX fields
     dx_number = StringField(
-        "DX number",
+        "DX number (optional)",
         widget=GovTextInput(heading_class="govuk-fieldset__legend--m", classes="govuk-input--width-20"),
         validators=[
-            InputRequired(message="Enter the DX number"),
+            Optional(),
             Length(max=20, message="DX number must be 20 characters or fewer"),
         ],
     )
 
     dx_centre = StringField(
-        "DX centre",
+        "DX centre (optional)",
         widget=GovTextInput(heading_class="govuk-fieldset__legend--m", classes="govuk-input--width-20"),
         validators=[
-            InputRequired(message="Enter the DX centre"),
+            Optional(),
             Length(max=50, message="DX centre must be 50 characters or fewer"),
         ],
     )

--- a/tests/functional_tests/add_a_new_office/test_office_contact_details.py
+++ b/tests/functional_tests/add_a_new_office/test_office_contact_details.py
@@ -59,10 +59,6 @@ def test_required_fields_validation(page: Page):
     expect(page.get_by_text("Error: Enter address line 1, typically the building and street")).to_be_visible()
     expect(page.get_by_text("Error: Enter the town or city")).to_be_visible()
     expect(page.get_by_text("Error: Enter the postcode")).to_be_visible()
-    expect(page.get_by_text("Error: Enter the telephone number")).to_be_visible()
-    expect(page.get_by_text("Error: Enter the email address")).to_be_visible()
-    expect(page.get_by_text("Error: Enter the DX number")).to_be_visible()
-    expect(page.get_by_text("Error: Enter the DX centre")).to_be_visible()
 
 
 @pytest.mark.usefixtures("live_server")


### PR DESCRIPTION
## What does this pull request do?

Makes the following fields optional when changing office contact details:
* Telephone number
* Email address
* DX number
* DX centre
Retains validation on those fields if values are entered.

[Link to story](https://dsdmoj.atlassian.net/browse/MAPD-121)

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
