### PR TITLE
MAPD-146 cleanup helm deploys after merge/close

### DIFF
--- a/.github/workflows/cleanup-release.yml
+++ b/.github/workflows/cleanup-release.yml
@@ -1,0 +1,45 @@
+# Uninstalls the dev helm chart when a PR is merged, or closed
+name: Clean up the dev release
+
+run-name: Clean up ${{ github.head_ref || github.ref_name }}
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  clean-up-release:
+    name: Clean up release
+    environment: uat
+    runs-on: ubuntu-latest
+    permissions:
+        id-token: write # This is required for requesting the JWT
+        contents: read  # This is required for actions/checkout
+
+    steps:
+      - name: Authenticate to the cluster
+        env:
+          KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
+          KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
+        run: |
+          echo "${{ secrets.KUBE_CERT }}" > ca.crt
+          kubectl config set-cluster ${KUBE_CLUSTER} --certificate-authority=./ca.crt --server=https://${KUBE_CLUSTER}
+          kubectl config set-credentials deploy-user --token=${{ secrets.KUBE_TOKEN }}
+          kubectl config set-context ${KUBE_CLUSTER} --cluster=${KUBE_CLUSTER} --user=deploy-user --namespace=${KUBE_NAMESPACE}
+          kubectl config use-context ${KUBE_CLUSTER}
+
+      - name: Uninstall the helm chart
+        env:
+          # head_ref is set if the workflow was triggered by a PR, ref_name is used if the workflow was trigged by a push.
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+        run: |
+            export CLEANED_BRANCH_NAME=$(echo ${BRANCH_NAME} \
+            | sed 's/^feature[-/]//' \
+            | sed 's:^\w*\/::' \
+            | tr -s ' _/[]().' '-' \
+            | tr '[:upper:]' '[:lower:]' \
+            | cut -c1-28 \
+            | sed 's/-$//')
+
+            helm uninstall "${CLEANED_BRANCH_NAME}" --namespace="${KUBE_NAMESPACE}"


### PR DESCRIPTION
## What does this pull request do?

Deletes helm deployments after a PR is closed or merged. We currently have 35+ helm deployments in UAT. 

[Link to story](https://dsdmoj.atlassian.net/browse/MAPD-146)

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
