### PR TITLE
Update libc-bin to fix CVE-2025-4802

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update \
     perl-base \
     libxslt1.1 \
     libxslt1-dev \
+    libc-bin \
     && rm -rf /var/lib/apt/lists/*
 
 # Upgrade libslt1 to install the latest security update


### PR DESCRIPTION
## What does this pull request do?

- Updates libc-bin to fix [CVE-2025-4802](https://avd.aquasec.com/nvd/2025/cve-2025-4802/)

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
