### PR TITLE
Support govuk summary list data tables

### DIFF
--- a/app/components/tables.py
+++ b/app/components/tables.py
@@ -128,8 +128,9 @@ class DataTable:
         return [{key: column.get(key, "") for key in ("id", "text", "classes")} for column in self.structure]
 
     def to_govuk_params(self, **kwargs) -> dict[str, Any]:
-        """Convert table to govukTable dictionary for template rendering.
+        """Convert table to dictionary for template rendering.
         Usage: {{ govukTable(table.to_govuk_params()) }}
+        With overrides: {{ govukTable(table.to_govuk_params(classes="custom-class")) }}
         """
         params = {
             "head": self.get_headings(),
@@ -139,8 +140,7 @@ class DataTable:
         }
         if self.sortable_table:
             params.update({"attributes": {"data-module": SORTABLE_TABLE_MODULE}})
-
-        params.update(kwargs)
+        params.update(kwargs)  # Allow overriding any defaults
         return params
 
 

--- a/app/components/tables.py
+++ b/app/components/tables.py
@@ -199,7 +199,7 @@ class TransposedDataTable(DataTable):
         summary_rows = []
 
         for row in table_rows:
-            if len(row) >= 2:  # Should have at least key and one value
+            if len(row) == 2:  # Should have at least key and one value
                 summary_rows.append({"key": row[0], "value": row[1]})
 
         params = {

--- a/app/components/tables.py
+++ b/app/components/tables.py
@@ -24,6 +24,15 @@ class TableStructure(TypedDict, total=False):
     html_renderer: Callable[[dict[str, str]], str] | str | None  # Function that takes row data, returns HTML string
 
 
+class Card(TypedDict, total=False):
+    """Card used for rendering a header area to a GOV.UK summary list. Only supported by TransposedDataTables"""
+
+    title: str
+    action_text: str | None
+    action_url: str | None
+    action_visually_hidden_text: str | None
+
+
 class Cell(TypedDict, total=False):
     """Represents a single table cell in the rendered output."""
 
@@ -119,9 +128,8 @@ class DataTable:
         return [{key: column.get(key, "") for key in ("id", "text", "classes")} for column in self.structure]
 
     def to_govuk_params(self, **kwargs) -> dict[str, Any]:
-        """Convert table to dictionary for template rendering.
+        """Convert table to govukTable dictionary for template rendering.
         Usage: {{ govukTable(table.to_govuk_params()) }}
-        With overrides: {{ govukTable(table.to_govuk_params(classes="custom-class")) }}
         """
         params = {
             "head": self.get_headings(),
@@ -131,7 +139,8 @@ class DataTable:
         }
         if self.sortable_table:
             params.update({"attributes": {"data-module": SORTABLE_TABLE_MODULE}})
-        params.update(kwargs)  # Allow overriding any defaults
+
+        params.update(kwargs)
         return params
 
 
@@ -139,10 +148,15 @@ class TransposedDataTable(DataTable):
     first_cell_is_header = True  # The first cell in each row will be a bold table header
 
     def __init__(
-        self, structure: list[TableStructure], data: Data | RowData, headings: list[str] | None = None
+        self,
+        structure: list[TableStructure],
+        data: Data | RowData,
+        headings: list[str] | None = None,
+        card: Card | None = None,
     ) -> None:
         """Helper class for generating the head and rows required for displaying transposed GOV.UK Tables."""
         super().__init__(structure, data)
+        self.card = card
 
         if headings is not None:
             expected_heading_count = len(self.data) + 1
@@ -175,6 +189,44 @@ class TransposedDataTable(DataTable):
 
     def get_headings(self) -> list[dict[str, str]]:
         return [{"text": heading, "classes": ""} for heading in self.headings]
+
+    def to_summary_govuk_params(self, **kwargs) -> dict[str, Any]:
+        """Convert transposed table to govukSummaryList dictionary for template rendering.
+        Usage: {{ govukSummaryList(table.to_summary_govuk_params()) }}
+
+        """
+        table_rows = self.get_rows()
+        summary_rows = []
+
+        for row in table_rows:
+            if len(row) >= 2:  # Should have at least key and one value
+                summary_rows.append({"key": row[0], "value": row[1]})
+
+        params = {
+            "rows": summary_rows,
+            "classes": DEFAULT_TABLE_CLASSES,
+        }
+
+        if self.card:
+            card = {"title": {"text": self.card.get("title")}}
+            if self.card.get("action_text"):
+                card.update(
+                    {
+                        "actions": {
+                            "items": [
+                                {
+                                    "text": self.card["action_text"],
+                                    "href": self.card["action_url"],
+                                    "visuallyHiddenText": self.card.get("action_visually_hidden_text"),
+                                }
+                            ]
+                        }
+                    }
+                )
+            params["card"] = card
+
+        params.update(kwargs)
+        return params
 
 
 class RadioDataTable(DataTable):

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -5,7 +5,7 @@ from typing import Literal, NoReturn
 from flask import abort, current_app, redirect, render_template, request, session, url_for
 from flask.views import MethodView
 
-from app.components.tables import DataTable, TableStructure, TransposedDataTable, add_field
+from app.components.tables import Card, DataTable, TableStructure, TransposedDataTable, add_field
 from app.main.utils import add_new_provider
 from app.models import Firm, Office
 from app.utils.formatting import (
@@ -175,9 +175,22 @@ class ViewProvider(MethodView):
         return office_tables
 
     def get_contact_table(self, firm: Firm) -> DataTable:
-        contact_rows, contact_data = [], {}
-        add_field(contact_rows, contact_data, "Firstname Lastname", "Name")
-        contact_table = TransposedDataTable(structure=contact_rows, data=contact_data) if contact_rows else None
+        contact_table_structure = []
+        contact_data = {}
+
+        add_field(contact_table_structure, contact_data, "Liason manager", "Job title")
+        add_field(contact_table_structure, contact_data, "0118 9998819", "Telephone number")
+        add_field(contact_table_structure, contact_data, "name@domain.com", "Email address")
+        add_field(contact_table_structure, contact_data, "domain.com", "Website")
+        add_field(contact_table_structure, contact_data, "1st Jan 2025", "Active from")
+
+        card: Card = {"title": "Firstname Lastname", "action_text": "Change liaison manager", "action_url": "#"}
+
+        contact_table = (
+            TransposedDataTable(structure=contact_table_structure, data=contact_data, card=card)
+            if contact_data
+            else None
+        )
         return contact_table
 
     def get_context(self, firm):

--- a/app/templates/view-provider-legal-services-provider.html
+++ b/app/templates/view-provider-legal-services-provider.html
@@ -45,7 +45,7 @@
 
 {% if subpage == "contact" %}
     <h3 class="govuk-heading-m">Contacts</h3>
-    {{ govukTable(contact_table.to_govuk_params()) }}
+    {{ govukSummaryList(contact_table.to_summary_govuk_params()) }}
 
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
## What does this pull request do?

- Add support for govUkSummaryList and header cards for TransposedDataTables

<img width="841" height="1105" alt="Screenshot 2025-09-09 at 17 34 18" src="https://github.com/user-attachments/assets/08156b52-1356-49b2-9cb0-a467bf53678d" />

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
