### PR TITLE
Fix back links on view provider page

### DIFF
--- a/app/static/src/js/back_link.js
+++ b/app/static/src/js/back_link.js
@@ -6,6 +6,10 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!backButton) {
         return;
     }
+
+    if (backButton.hasAttribute("href")) {
+        return;
+    }
     
     backButton.addEventListener('click', (e) => {
         e.preventDefault();

--- a/app/templates/components/back_link.html
+++ b/app/templates/components/back_link.html
@@ -1,8 +1,8 @@
 {% macro govukBackLink(params={}) %}
 {% from "govuk_frontend_jinja/macros/attributes.html" import govukAttributes -%}
 
-<button id="backLink" {% if params.href %}href="{{ params.href }}"{% endif %} class="govuk-back-link back-link {%- if params.classes %} {{ params.classes }}{% endif %}"
+<a id="backLink" {% if params.href %}href="{{ params.href }}"{% endif %} class="govuk-back-link back-link {%- if params.classes %} {{ params.classes }}{% endif %}"
   {{- govukAttributes(params.attributes) }}>
   {{- params.html | safe if params.html else (params.text if params.text else "Back") -}}
-</button>
+</a>
 {% endmacro %}

--- a/app/templates/providers.html
+++ b/app/templates/providers.html
@@ -6,11 +6,6 @@
 {%- from 'components/back_link.html' import govukBackLink -%}
 {%- from 'macros/flash_messages.html' import renderFlashMessages %}
 
-{% block beforeContent %}
-  {{ super() }}
-  {{ govukBackLink() }}
-{% endblock %}
-
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">

--- a/tests/functional_tests/test_view_provider.py
+++ b/tests/functional_tests/test_view_provider.py
@@ -131,3 +131,39 @@ def test_lsp_contact(page):
     expect(page.locator("dl")).to_contain_text("Website")
     expect(page.locator("dl")).to_contain_text("Active from")
     expect(page.get_by_role("link", name="Change liaison manager")).to_be_visible()
+
+
+@pytest.mark.usefixtures("live_server")
+def test_back_link_lsp(page):
+    page.get_by_role("button", name="Start now").click()
+    # Perform a blank search to view all providers
+    page.get_by_role("button", name="Search").click()
+    page.get_by_role("link", name="SMITH & PARTNERS SOLICITORS").click()
+
+    page.get_by_role("link", name="Back to all providers").click()
+    expect(page.get_by_role("heading", name="Provider records")).to_be_visible()
+
+    page.get_by_role("button", name="Search").click()
+    page.get_by_role("link", name="SMITH & PARTNERS SOLICITORS").click()
+
+    page.get_by_role("link", name="Offices").click()
+    page.get_by_role("link", name="Back to all providers").click()
+    expect(page.get_by_role("heading", name="Provider records")).to_be_visible()
+
+
+@pytest.mark.usefixtures("live_server")
+def test_back_link_chambers(page):
+    page.get_by_role("button", name="Start now").click()
+    # Perform a blank search to view all providers
+    page.get_by_role("button", name="Search").click()
+    page.get_by_role("link", name="JOHNSON LEGAL SERVICES").click()
+
+    page.get_by_role("link", name="Back to all providers").click()
+    expect(page.get_by_role("heading", name="Provider records")).to_be_visible()
+
+    page.get_by_role("button", name="Search").click()
+    page.get_by_role("link", name="JOHNSON LEGAL SERVICES").click()
+
+    page.get_by_role("link", name="Barristers and advocates").click()
+    page.get_by_role("link", name="Back to all providers").click()
+    expect(page.get_by_role("heading", name="Provider records")).to_be_visible()


### PR DESCRIPTION
## What does this pull request do?

### Fixes the back link on the view provider page to always go back to the provider list
- Fixes an issue where there were duplicate back links on the provider list page

https://github.com/user-attachments/assets/20c6b28c-9d06-40de-bbeb-12f7ee3d5fee

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
