### PR TITLE
Use slim docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,24 +10,13 @@ RUN npm run build
 
 FROM $BASE_IMAGE AS base
 ARG REQUIREMENTS_FILE=requirements-production.txt
-# Update package directory and install latest versions, then clean apt lists
-RUN apt-get update \
-    && apt-get install  --only-upgrade -y \
-    perl-base \
-    libxslt1.1 \
-    libxslt1-dev \
-    libc-bin \
-    linux-libc-dev \
-    libexpat1 \
-    libperl5.36 \
-    libpq-dev \
-    libsqlite3-0 \
-    libxml2 \
-    imagemagick \
-    && rm -rf /var/lib/apt/lists/*
-
-# Update package lists and install required packages
+# Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    gcc \
+    python3-dev \
+    libpq-dev \
+    libxml2 \
     libxslt1.1 \
     libxslt1-dev \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=python:3.13-bookworm
+ARG BASE_IMAGE=python:3.13-slim-bookworm
 
 FROM node:lts-iron AS node_build
 WORKDIR /home/node
@@ -26,9 +26,11 @@ RUN apt-get update \
     imagemagick \
     && rm -rf /var/lib/apt/lists/*
 
-# Upgrade libslt1 to install the latest security update
-# https://nvd.nist.gov/vuln/detail/CVE-2025-7424
-RUN apt-get install --only-upgrade libxslt1.1 libxslt1-dev -y
+# Update package lists and install required packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libxslt1.1 \
+    libxslt1-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 # Clean up cached package files & index files for a smaller image size
 RUN apt-get clean

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,6 @@ ARG REQUIREMENTS_FILE=requirements-production.txt
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
-    gcc \
-    python3-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Clean up cached package files & index files for a smaller image size

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     gcc \
     python3-dev \
-    libpq-dev \
-    libxml2 \
-    libxslt1.1 \
-    libxslt1-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Clean up cached package files & index files for a smaller image size


### PR DESCRIPTION
## What does this pull request do?

I have removed packages that were added in response to security warnings. These were required due to the base image, now we are using the `slim` version we don't need these packages. Removed all the ones that 

PRs we have added fixes to the dockerfile:
https://github.com/ministryofjustice/laa-manage-a-providers-data/pull/41/files
https://github.com/ministryofjustice/laa-manage-a-providers-data/pull/65/files


## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
