### PR TITLE
Refactor view registration to explicitly call register views

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -9,7 +9,7 @@ bp = Blueprint("main", __name__, template_folder="templates")
 # Import modules after blueprint creation to avoid circular imports
 from app.main import middleware  # noqa: E402,F401
 from app.main import routes  # noqa: E402,F401
-from app.main import add_a_new_office, add_a_new_provider  # noqa: E402,F401
+from app.main import add_a_new_office, add_a_new_provider  # noqa: E402
 
 register_form_view(form_class=ProviderListForm, view_class=ProviderList, blueprint=bp)
 
@@ -27,3 +27,6 @@ bp.add_url_rule(
 )
 
 bp.add_url_rule("/provider/<firm:firm>/office/<office:office>", view_func=ViewOffice.as_view("view_office"))
+
+add_a_new_provider.register_views(bp)
+add_a_new_office.register_views(bp)

--- a/app/main/add_a_new_office/__init__.py
+++ b/app/main/add_a_new_office/__init__.py
@@ -1,10 +1,9 @@
-from app.main import bp
 from app.main.add_a_new_office.forms import AddOfficeForm, OfficeContactDetailsForm
 from app.main.add_a_new_office.views import AddOfficeFormView, OfficeContactDetailsFormView
 from app.utils import register_form_view
 
 
-def register_views():
+def register_views(bp):
     register_form_view(form_class=AddOfficeForm, view_class=AddOfficeFormView, blueprint=bp, endpoint="add_office")
     register_form_view(
         form_class=OfficeContactDetailsForm,
@@ -12,6 +11,3 @@ def register_views():
         blueprint=bp,
         endpoint="add_office_contact_details",
     )
-
-
-register_views()

--- a/app/main/add_a_new_provider/__init__.py
+++ b/app/main/add_a_new_provider/__init__.py
@@ -1,4 +1,3 @@
-from app.main import bp
 from app.utils import register_form_view
 
 from .forms import (
@@ -29,7 +28,7 @@ from .views import (
 )
 
 
-def register_views():
+def register_views(bp):
     register_form_view(form_class=AddProviderForm, view_class=AddProviderFormView, blueprint=bp)
 
     register_form_view(form_class=LspDetailsForm, view_class=LspDetailsFormView, blueprint=bp)
@@ -57,6 +56,3 @@ def register_views():
     register_form_view(
         form_class=AddAdvocateForm, view_class=AddAdvocateFormView, blueprint=bp, endpoint="add_advocate_form"
     )
-
-
-register_views()


### PR DESCRIPTION
## What does this pull request do?

- Refactors the view registration to explicitly call `register_views` on sub-modules.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
