### PR TITLE
Reduce replicaCount on staging

### DIFF
--- a/helm_deploy/laa-manage-a-providers-data/values/values-staging.yaml
+++ b/helm_deploy/laa-manage-a-providers-data/values/values-staging.yaml
@@ -1,5 +1,5 @@
 environment: "staging"
-replicaCount: 4
+replicaCount: 1
 
 ingress:
   enabled: true
@@ -10,7 +10,7 @@ whitelist:
 
 pdb:
   enabled: true
-  minAvailable: 2
+  minAvailable: 1
 
 envVars:
   PDA_USE_MOCK_API:


### PR DESCRIPTION
## What does this pull request do?

- Reduces the replicaCount of pods on the staging environment to be 1, while we are using the mock API.

We are doing this as the mock API runs in memory, and having four instances of the app running causes issues where the different sources of data disagree.

This should be set back to 4 when we use the proper PDA.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
