### PR TITLE
Fix: Add "Active to" date to Contacts

### DIFF
--- a/app/main/utils.py
+++ b/app/main/utils.py
@@ -158,7 +158,9 @@ def change_liaison_manager(contact: Contact, firm_id: int, show_success_message:
         for existing_contact in contacts:
             if existing_contact.job_title == "Liaison manager" and existing_contact.primary == "Y":
                 # Set this contact to non-primary
-                updated_contact = existing_contact.model_copy(update={"primary": "N"})
+                updated_contact = existing_contact.model_copy(
+                    update={"primary": "N", "inactive_date": date.today().isoformat()}
+                )
                 try:
                     pda.update_contact(firm_id, office.firm_office_code, updated_contact)
                 except ProviderDataApiError:
@@ -175,7 +177,7 @@ def change_liaison_manager(contact: Contact, firm_id: int, show_success_message:
             "vendor_site_id": office.firm_office_id,
             "job_title": "Liaison manager",
             "primary": "Y",
-            "active_from": date.today().isoformat(),
+            "creation_date": date.today().isoformat(),
         }
 
         office_contact = contact.model_copy(update=contact_updates)

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -60,7 +60,9 @@ def get_contact_tables(firm: Firm, head_office: Office = None) -> list[DataTable
         contact_table.add_row(contact.telephone_number, "Telephone number")
         contact_table.add_row(contact.email_address, "Email address")
         contact_table.add_row(contact.website, "Website")
-        contact_table.add_row(contact.active_from, "Active from", format_date)
+        contact_table.add_row(contact.creation_date, "Active from", format_date)
+        if contact.inactive_date:
+            contact_table.add_row(contact.inactive_date, "Active to", format_date)
 
         contact_tables.append(contact_table)
 

--- a/app/models.py
+++ b/app/models.py
@@ -188,7 +188,8 @@ class Contact(BaseModel):
     website: Optional[str] = Field(default=None)
     job_title: Optional[str] = Field(alias="jobTitle", default=None)
     primary: str = Field(default="N")
-    active_from: Optional[str] = Field(alias="activeFrom", default=None)
+    creation_date: Optional[str] = Field(alias="creationDate", default=None)
+    inactive_date: Optional[str] = Field(alias="inactiveDate", default=None)
 
     def to_api_dict(self) -> dict:
         """Export as camelCase dictionary for API calls."""

--- a/app/pda/fixtures/contacts.json
+++ b/app/pda/fixtures/contacts.json
@@ -9,7 +9,7 @@
       "website": "https://www.smithpartners.com",
       "jobTitle": "Liaison manager",
       "primary": "Y",
-      "activeFrom": "2024-01-15"
+      "creationDate": "2025-01-15"
     },
     {
       "vendorSiteId": 101,
@@ -20,7 +20,8 @@
       "website": null,
       "jobTitle": "Liaison manager",
       "primary": "N",
-      "activeFrom": "2024-03-10"
+      "creationDate": "2024-03-10",
+      "inactiveDate": "2025-01-15"
     },
     {
       "vendorSiteId": 101,
@@ -31,7 +32,8 @@
       "website": "https://www.alicebrown.com",
       "jobTitle": "Liaison manager",
       "primary": "N",
-      "activeFrom": "2024-06-22"
+      "creationDate": "2024-01-22",
+      "inactiveDate": "2024-03-10"
     },
     {
       "vendorSiteId": 102,
@@ -42,7 +44,7 @@
       "website": "https://www.johnsonlegal.com",
       "jobTitle": "Liaison manager",
       "primary": "Y",
-      "activeFrom": "2023-11-05"
+      "creationDate": "2023-11-05"
     },
     {
       "vendorSiteId": 103,
@@ -53,7 +55,7 @@
       "website": "https://www.brownassociates.com",
       "jobTitle": "Liaison manager",
       "primary": "Y",
-      "activeFrom": "2024-02-28"
+      "creationDate": "2024-05-12"
     },
     {
       "vendorSiteId": 103,
@@ -64,7 +66,8 @@
       "website": null,
       "jobTitle": "Liaison manager",
       "primary": "N",
-      "activeFrom": "2024-05-12"
+      "creationDate": "2024-02-12",
+      "inactiveDate": "2024-15-12"
     },
     {
       "vendorSiteId": 104,
@@ -75,7 +78,7 @@
       "website": "https://www.davischambers.com",
       "jobTitle": "Liaison manager",
       "primary": "Y",
-      "activeFrom": "2023-09-18"
+      "creationDate": "2023-09-18"
     },
     {
       "vendorSiteId": 105,
@@ -86,7 +89,7 @@
       "website": null,
       "jobTitle": "Liaison manager",
       "primary": "Y",
-      "activeFrom": "2024-04-07"
+      "creationDate": "2024-04-07"
     },
     {
       "vendorSiteId": 201,
@@ -97,7 +100,7 @@
       "website": "https://www.scottishlegal.com",
       "jobTitle": "Liaison manager",
       "primary": "Y",
-      "activeFrom": "2023-12-20"
+      "creationDate": "2023-12-20"
     },
     {
       "vendorSiteId": 401,
@@ -108,7 +111,7 @@
       "website": "https://www.alandavies.com",
       "jobTitle": "Liaison manager",
       "primary": "Y",
-      "activeFrom": "2025-09-25"
+      "creationDate": "2025-09-25"
     }
   ]
 }

--- a/app/pda/mock_api.py
+++ b/app/pda/mock_api.py
@@ -639,10 +639,10 @@ class MockProviderDataApi:
 
         office_id = office_data.get("firmOfficeId")
 
-        # Set the vendor_site_id to the office ID and active_from to today in ISO format
+        # Set the vendor_site_id to the office ID and creation_date to today in ISO format
         updates = {"vendor_site_id": office_id}
-        if not contact.active_from:
-            updates["active_from"] = date.today().isoformat()
+        if not contact.creation_date:
+            updates["creation_date"] = date.today().isoformat()
 
         updated_contact = contact.model_copy(update=updates)
 

--- a/app/templates/macros/contact_tables.html
+++ b/app/templates/macros/contact_tables.html
@@ -16,7 +16,7 @@
             {% endset %}
             
             {{ govukDetails({
-                "summaryText": "Show " ~ (contact_tables|length - 1) ~ " additional contact" ~ ("s" if contact_tables|length > 2 else ""),
+                "summaryText": "Previous contacts",
                 "html": additional_contacts_html
             }) }}
         {% endif %}

--- a/tests/functional_tests/modify_provider/test_change_liaison_manager.py
+++ b/tests/functional_tests/modify_provider/test_change_liaison_manager.py
@@ -146,4 +146,4 @@ def test_change_liaison_manager_replaces_existing_primary(page: Page):
     expect(page.get_by_text("newprimary@example.com")).to_be_visible()
 
     current_date = date.today().strftime("%d %b %Y")
-    expect(page.get_by_text(current_date)).to_be_visible()
+    expect(page.get_by_text(current_date)).to_have_count(2)  # Active from date on new provider & active to date on

--- a/tests/functional_tests/test_view_office.py
+++ b/tests/functional_tests/test_view_office.py
@@ -138,9 +138,9 @@ def test_office_contact(page):
     expect(page.get_by_text("123 4567")).to_be_visible()
     expect(page.get_by_role("term").filter(has_text="Email address")).to_be_visible()
     expect(page.get_by_text("sarah.johnson@smithpartners.")).to_be_visible()
-    expect(page.get_by_text("Show 2 additional contacts")).to_be_visible()
+    expect(page.get_by_text("Previous contacts")).to_be_visible()
 
-    page.get_by_text("Show 2 additional contacts").click()
+    page.get_by_text("Previous contacts").click()
     expect(page.get_by_role("heading", name="David Smith")).to_be_visible()
     expect(page.get_by_role("heading", name="Alice Brown")).to_be_visible()
 

--- a/tests/functional_tests/test_view_provider_contacts.py
+++ b/tests/functional_tests/test_view_provider_contacts.py
@@ -32,8 +32,8 @@ def test_view_provider_contacts_multiple_contacts_with_details(page: Page):
     # Verify the primary contact is shown directly
     expect(page.get_by_text("Sarah Johnson", exact=True)).to_be_visible()
 
-    # Check that there's a details component for additional contacts (now 2 additional)
-    expect(page.get_by_text("Show 2 additional contacts")).to_be_visible()
+    # Check that there's a details component for previous contacts
+    expect(page.get_by_text("Previous contacts")).to_be_visible()
 
     # The secondary contacts should not be visible initially
     expect(page.get_by_text("David Smith", exact=True)).not_to_be_visible()
@@ -41,8 +41,8 @@ def test_view_provider_contacts_multiple_contacts_with_details(page: Page):
     expect(page.get_by_text("david.smith@smithpartners.com")).not_to_be_visible()
     expect(page.get_by_text("alice.brown@smithpartners.com")).not_to_be_visible()
 
-    # Click the details to reveal additional contacts
-    page.get_by_text("Show 2 additional contacts").click()
+    # Click the details to reveal previous contacts
+    page.get_by_text("Previous contacts").click()
 
     # Now both secondary contacts should be visible
     expect(page.get_by_text("David Smith", exact=True)).to_be_visible()
@@ -53,7 +53,7 @@ def test_view_provider_contacts_multiple_contacts_with_details(page: Page):
     expect(page.get_by_text("0116 123 4569")).to_be_visible()
     expect(page.get_by_text("Active to")).to_be_visible()
 
-    # Check that active from dates are visible for additional contacts
+    # Check that active from dates are visible for previous contacts
     expect(page.get_by_text("10 Mar 2024")).to_have_count(
         2
     )  # David Smith's Active from date and Alice Brown's Active to date
@@ -73,7 +73,7 @@ def test_view_provider_contacts_single_contact_no_details(page: Page):
 
     # Should not show any details component
     expect(page.get_by_text("Show")).not_to_be_visible()
-    expect(page.get_by_text("additional contact")).not_to_be_visible()
+    expect(page.get_by_text("previous contacts")).not_to_be_visible()
 
 
 @pytest.mark.usefixtures("live_server")
@@ -99,13 +99,13 @@ def test_view_provider_contacts_details_component_functionality(page: Page):
     expect(page.get_by_text("David Smith", exact=True)).not_to_be_visible()
 
     # Click to open
-    page.get_by_text("Show 2 additional contacts").click()
+    page.get_by_text("Previous contacts").click()
 
     # Details should now be open
     expect(page.get_by_text("David Smith", exact=True)).to_be_visible()
 
     # Click to close
-    page.get_by_text("Show 2 additional contacts").click()
+    page.get_by_text("Previous contacts").click()
 
     # Details should be closed again
     expect(page.get_by_text("David Smith", exact=True)).not_to_be_visible()

--- a/tests/functional_tests/test_view_provider_contacts.py
+++ b/tests/functional_tests/test_view_provider_contacts.py
@@ -19,8 +19,8 @@ def test_view_provider_contacts_primary_contact_displayed(page: Page):
     expect(page.get_by_text("https://www.smithpartners.com")).to_be_visible()
     expect(page.get_by_text("Liaison manager", exact=True)).to_have_count(3)
 
-    # Check that the active from date is displayed (Sarah Johnson's date: 2024-01-15)
-    expect(page.get_by_text("15 Jan 2024")).to_be_visible()
+    # Check that the active from date is displayed (Sarah Johnson's Active from date and David Smith's Active to date: 2025-01-15)
+    expect(page.get_by_text("15 Jan 2025")).to_have_count(2)
 
 
 @pytest.mark.usefixtures("live_server")
@@ -51,10 +51,13 @@ def test_view_provider_contacts_multiple_contacts_with_details(page: Page):
     expect(page.get_by_text("alice.brown@smithpartners.com")).to_be_visible()
     expect(page.get_by_text("0116 123 4568")).to_be_visible()
     expect(page.get_by_text("0116 123 4569")).to_be_visible()
+    expect(page.get_by_text("Active to")).to_be_visible()
 
     # Check that active from dates are visible for additional contacts
-    expect(page.get_by_text("10 Mar 2024")).to_be_visible()  # David Smith's date
-    expect(page.get_by_text("22 Jun 2024")).to_be_visible()  # Alice Brown's date
+    expect(page.get_by_text("10 Mar 2024")).to_have_count(
+        2
+    )  # David Smith's Active from date and Alice Brown's Active to date
+    expect(page.get_by_text("22 Jan 2024")).to_be_visible()  # Alice Brown's Active from date
 
 
 @pytest.mark.usefixtures("live_server")


### PR DESCRIPTION
## What does this pull request do?

- **Add "Active to" dates to Liaison Managers**
- **Change "Show X additional contacts" to "Previous contacts"**

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
