### PR TITLE
fix: Ensure functional test date format matches output date format

### DIFF
--- a/app/utils/formatting.py
+++ b/app/utils/formatting.py
@@ -46,7 +46,7 @@ def format_date(date: str | datetime.date) -> str:
             return date
 
     if isinstance(date, datetime.date):
-        # Format as "20 Jan 2023"
+        # Format without leading zero, "1 Feb 2020", "20 Jan 2023"
         return date.strftime("%-d %b %Y")
     raise ValueError(f"{date} is not a valid date.")
 

--- a/tests/functional_tests/modify_provider/test_change_liaison_manager.py
+++ b/tests/functional_tests/modify_provider/test_change_liaison_manager.py
@@ -145,5 +145,6 @@ def test_change_liaison_manager_replaces_existing_primary(page: Page):
     expect(page.get_by_text("020 7947 6330")).to_be_visible()
     expect(page.get_by_text("newprimary@example.com")).to_be_visible()
 
-    current_date = date.today().strftime("%d %b %Y")
+    # Note the format does not zero pad the day of the month
+    current_date = date.today().strftime("%-d %b %Y")
     expect(page.get_by_text(current_date)).to_be_visible()


### PR DESCRIPTION
## What does this pull request do?

This fixes an issue in the functional tests which cause failures during the first 9 days of the month.

## Any other changes that would benefit highlighting?

Intentionally left blank.
